### PR TITLE
fix: Fix parsing `Vector{T}` from `Expr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://curtd.github.io/MacroUtilities.jl/dev/)
 [![Build Status](https://github.com/curtd/MacroUtilities.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/curtd/MacroUtilities.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-# MacroUtilities
 `MacroUtilities.jl` provides useful utilities for manipulating expressions and writing macros in Julia.
 
 ## Keyword Arguments From Expressions

--- a/src/parsing/kv_types.jl
+++ b/src/parsing/kv_types.jl
@@ -36,12 +36,12 @@ function _from_expr(::Type{KVSpecExpr}, expr)
     spec = KVSpecExpr(; key=_key)
 
     args = @switch _value begin 
-        @case Expr(:tuple, args...) 
+        @case Expr(:tuple, args...) || Expr(:vect, args...)
            args
         @case Expr(:(=), key, value)
             [_value]
         @case _ 
-            return ArgumentError("In expression, `$(_kv.key) = rhs`, rhs (= `$(_kv.value)`) is not a valid key-value specifier expression")
+            return ArgumentError("In expression, `$(_key) = rhs`, rhs (= `$(_value)`) is not a valid key-value specifier expression")
     end
     for kwarg in args 
         kv = _from_expr(KVExpr, kwarg)

--- a/test/TestMacroUtilities.jl
+++ b/test/TestMacroUtilities.jl
@@ -41,6 +41,7 @@ module TestMacroUtilities
             @test_cases begin 
                 input           |  T      | output
                 :([])           |  Symbol | Symbol[]
+                :(abc)          |  Symbol | [:abc]
                 :([abc])        |  Symbol | [:abc]
                 :([abc, def])   |  Symbol | [:abc, :def]
                 :((abc, def))   |  Symbol | [:abc, :def]


### PR DESCRIPTION
Singleton values of type `T` will now be properly parsed as a `Vector{T}`.
Added handling for parsing vectors where `T` is a `Union` type.