### PR TITLE
feat: Added `@method_def_constant` on Julia < 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.5.1"
 [deps]
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [compat]
 MLStyle = "0.4.17"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,7 @@ CurrentModule = MacroUtilities
 ```@docs 
 @assert_type 
 @unpack_option
+@method_def_constant
 ```
 
 ## Keyword Arg Parsing  

--- a/src/MacroUtilities.jl
+++ b/src/MacroUtilities.jl
@@ -1,6 +1,6 @@
 module MacroUtilities
 
-    using MLStyle, OrderedCollections
+    using MLStyle, OrderedCollections, Tricks
 
     # General utilities 
     export @assert_type
@@ -37,6 +37,8 @@ module MacroUtilities
 
     export @parse_kwargs
 
+    export @method_def_constant
+
     include("utils.jl")
 
     include("parsing/_parsing.jl")
@@ -44,4 +46,6 @@ module MacroUtilities
     include("transformations/_transformations.jl")
 
     include("parse_kwargs/_parse_kwargs.jl")
+
+    include("macro_util.jl")
 end

--- a/src/macro_util.jl
+++ b/src/macro_util.jl
@@ -4,82 +4,83 @@ inner_param(::Type{MIME{S}}) where {S} = S
 get_constant_func((@nospecialize x)) = nothing
 constant_key_type((@nospecialize x)) = Any 
 
-@static if VERSION < v"1.10" 
-    
-    function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; transform_expr=nothing, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
-        f = from_expr(FuncCall, ref_method)
-        nargs = length(f.args)
-        val_arg_index::Union{Nothing,Int} = nothing 
-        local val_arg_expr::CurlyExpr{ValType, Any}
-        for i in 1:nargs 
-            g = _from_expr(CurlyExpr{ValType, Any}, f.args[i].type)
-            if !(g isa Exception)
-                val_arg_expr = g
-                val_arg_index = i 
-                break
-            end
-        end
-        (isnothing(val_arg_index) || length(val_arg_expr.args) != 1) && throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
-        if Meta.isexpr(val_arg_expr.args[1], :(::), 1)
-            ConstantType = only(val_arg_expr.args[1].args)
-        else
-            throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
-        end
-
-        ref_method_name = f.funcname
-        
-        _constant_method = gensym(get_constant_method)
-        get_constant_where_params = [Symbol("T$i") for i in 1:nargs]
-        get_constant_args = [FuncArg(; type=:(Type{$(get_constant_where_params[i])})) for i in 1:nargs if i != val_arg_index]
-        get_constant_body = FuncCall(; funcname=_constant_method, 
-            args=[FuncArg(; value=:(Tuple{$([ i == val_arg_index ? ValType : :(Type{$(get_constant_where_params[i])}) for i in 1:nargs]...)}))]
-        )
-        get_constant_method_def = FuncDef(; head=:(=), 
-            header=FuncCall(; funcname=get_constant_method, args=get_constant_args), 
-            whereparams= nargs > 1 ? [get_constant_where_params[i] for i in 1:nargs if i != val_arg_index] : not_provided,
-            body=Expr(:block, _sourceinfo, to_expr(get_constant_body)), 
-            line=something(_sourceinfo, not_provided), 
-            return_type=:(Vector{$ConstantType}))
-
-        get_constant_method_def = __doc__macro(get_constant_method_def)
-
-        output_expr = :($ConstantType[$inner_param(Base.fieldtype(m.sig,$(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(concrete_type_matches_only ? :(all(Base.fieldtype(m.sig, i) != Any for i in 1:nargs if i != $val_arg_index)) : true)])
-        if !isnothing(transform_expr)
-            output_expr = transform_expr(output_expr)
-        end
-        if ConstantType === :Symbol
-            returnvals = :(QuoteNode.(output))
-        else
-            returnvals = :(output)
-        end
-
-        return quote 
-            if isnothing($get_constant_func($ref_method_name))
-                @inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
-                    $_sourceinfo
-                    output = $output_expr
-                    ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:vect, ($returnvals)...))
-                    ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
-                    return ci
-                end
-
-                $(to_expr(get_constant_method_def))
-                $MacroUtilities.get_constant_func(::typeof($ref_method_name)) = $_constant_method
-                $MacroUtilities.constant_key_type(::typeof($ref_method_name)) = $ConstantType
-            end
+function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; transform_expr=nothing, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
+    f = from_expr(FuncCall, ref_method)
+    nargs = length(f.args)
+    val_arg_index::Union{Nothing,Int} = nothing 
+    local val_arg_expr::CurlyExpr{ValType, Any}
+    for i in 1:nargs 
+        g = _from_expr(CurlyExpr{ValType, Any}, f.args[i].type)
+        if !(g isa Exception)
+            val_arg_expr = g
+            val_arg_index = i 
+            break
         end
     end
+    (isnothing(val_arg_index) || length(val_arg_expr.args) != 1) && throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+    if Meta.isexpr(val_arg_expr.args[1], :(::), 1)
+        ConstantType = only(val_arg_expr.args[1].args)
+    else
+        throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+    end
 
-    """
-        @method_def_constant [ValType=Val] method_call get_constant_method
+    ref_method_name = f.funcname
+    
+    _constant_method = gensym(get_constant_method)
+    get_constant_where_params = [Symbol("T$i") for i in 1:nargs]
+    get_constant_args = [FuncArg(; type=:(Type{$(get_constant_where_params[i])})) for i in 1:nargs if i != val_arg_index]
+    get_constant_body = FuncCall(; funcname=_constant_method, 
+        args=[FuncArg(; value=:(Tuple{$([ i == val_arg_index ? ValType : :(Type{$(get_constant_where_params[i])}) for i in 1:nargs]...)}))]
+    )
+    get_constant_method_def = FuncDef(; head=:(=), 
+        header=FuncCall(; funcname=get_constant_method, args=get_constant_args), 
+        whereparams= nargs > 1 ? [get_constant_where_params[i] for i in 1:nargs if i != val_arg_index] : not_provided,
+        body=Expr(:block, _sourceinfo, to_expr(get_constant_body)), 
+        line=something(_sourceinfo, not_provided), 
+        return_type=:(Vector{$ConstantType}))
 
-    Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns a `Vector{S}` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
+    get_constant_method_def = __doc__macro(get_constant_method_def)
 
-    `get_constant_method` is a generated function and thus incurs no runtime overhead, but also contains backedges to each method instance of `f`, and so the output is recompiled when a new method definition of `f` is added. 
+    output_expr = :($ConstantType[$inner_param(Base.fieldtype(m.sig,$(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(concrete_type_matches_only ? :(all(Base.fieldtype(m.sig, i) != Any for i in 1:nargs if i != $val_arg_index)) : true)])
+    if !isnothing(transform_expr)
+        output_expr = transform_expr(output_expr)
+    end
+    if ConstantType === :Symbol
+        returnvals = :(QuoteNode.(output))
+    else
+        returnvals = :(output)
+    end
 
-    `ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
-    """
-    macro method_def_constant(args...)
+    return quote 
+        if isnothing($get_constant_func($ref_method_name))
+            @inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
+                $_sourceinfo
+                output = $output_expr
+                ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:vect, ($returnvals)...))
+                ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
+                return ci
+            end
+
+            $(to_expr(get_constant_method_def))
+            $MacroUtilities.get_constant_func(::typeof($ref_method_name)) = $_constant_method
+            $MacroUtilities.constant_key_type(::typeof($ref_method_name)) = $ConstantType
+        end
+    end
+end
+
+"""
+    @method_def_constant [ValType=Val] method_call get_constant_method
+
+Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns a `Vector{S}` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
+
+`get_constant_method` is a generated function and thus incurs no runtime overhead, but also contains backedges to each method instance of `f`, and so the output is recompiled when a new method definition of `f` is added. 
+
+`ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
+
+*Note*: This macro is a no-op unless the current Julia version is < 1.10
+"""
+macro method_def_constant(args...)
+    @static if VERSION < v"1.10"
         length(args) ≥ 1 || error("Must provide at least one argument")
         @parse_kwargs args[1] begin 
             ValType::Union{Symbol, Expr, Nothing} = nothing
@@ -93,6 +94,7 @@ constant_key_type((@nospecialize x)) = Any
             method_call, get_constant_method_name = args[2], args[3]
         end
         return method_def_constants_expr(method_call, get_constant_method_name, ValType) |> esc
+    else 
+        return :(nothing)
     end
-
 end

--- a/src/macro_util.jl
+++ b/src/macro_util.jl
@@ -1,0 +1,94 @@
+inner_param(::Type{Val{S}}) where {S} = S 
+inner_param(::Type{MIME{S}}) where {S} = S 
+
+get_constant_func((@nospecialize x)) = nothing
+constant_key_type((@nospecialize x)) = Any 
+
+function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; transform_expr=nothing, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
+    f = from_expr(FuncCall, ref_method)
+    nargs = length(f.args)
+    val_arg_index::Union{Nothing,Int} = nothing 
+    local val_arg_expr::CurlyExpr{ValType, Any}
+    for i in 1:nargs 
+        g = _from_expr(CurlyExpr{ValType, Any}, f.args[i].type)
+        if !(g isa Exception)
+            val_arg_expr = g
+            val_arg_index = i 
+            break
+        end
+    end
+    (isnothing(val_arg_index) || length(val_arg_expr.args) != 1) && throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+    if Meta.isexpr(val_arg_expr.args[1], :(::), 1)
+        ConstantType = only(val_arg_expr.args[1].args)
+    else
+        throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+    end
+
+    ref_method_name = f.funcname
+    
+    _constant_method = gensym(get_constant_method)
+    get_constant_where_params = [Symbol("T$i") for i in 1:nargs]
+    get_constant_args = [FuncArg(; type=:(Type{$(get_constant_where_params[i])})) for i in 1:nargs if i != val_arg_index]
+    get_constant_body = FuncCall(; funcname=_constant_method, 
+        args=[FuncArg(; value=:(Tuple{$([ i == val_arg_index ? ValType : :(Type{$(get_constant_where_params[i])}) for i in 1:nargs]...)}))]
+    )
+    get_constant_method_def = FuncDef(; head=:(=), 
+        header=FuncCall(; funcname=get_constant_method, args=get_constant_args), 
+        whereparams= nargs > 1 ? [get_constant_where_params[i] for i in 1:nargs if i != val_arg_index] : not_provided,
+        body=Expr(:block, _sourceinfo, to_expr(get_constant_body)), 
+        line=something(_sourceinfo, not_provided), 
+        return_type=:(Vector{$ConstantType}))
+
+    get_constant_method_def = __doc__macro(get_constant_method_def)
+
+    output_expr = :($ConstantType[$inner_param(Base.fieldtype(m.sig,$(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(concrete_type_matches_only ? :(all(Base.fieldtype(m.sig, i) != Any for i in 1:nargs if i != $val_arg_index)) : true)])
+    if !isnothing(transform_expr)
+        output_expr = transform_expr(output_expr)
+    end
+    if ConstantType === :Symbol
+        returnvals = :(QuoteNode.(output))
+    else
+        returnvals = :(output)
+    end
+
+    return quote 
+        if isnothing($get_constant_func($ref_method_name))
+            @inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
+                $_sourceinfo
+                output = $output_expr
+                ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:vect, ($returnvals)...))
+                ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
+                return ci
+            end
+
+            $(to_expr(get_constant_method_def))
+            $MacroUtilities.get_constant_func(::typeof($ref_method_name)) = $_constant_method
+            $MacroUtilities.constant_key_type(::typeof($ref_method_name)) = $ConstantType
+        end
+    end
+end
+
+"""
+    @method_def_constant [ValType=Val] method_call get_constant_method
+
+Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns a `Vector{S}` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
+
+`get_constant_method` is a generated function and thus incurs no runtime overhead, but also contains backedges to each method instance of `f`, and so the output is recompiled when a new method definition of `f` is added. 
+
+`ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
+"""
+macro method_def_constant(args...)
+    length(args) ≥ 1 || error("Must provide at least one argument")
+    @parse_kwargs args[1] begin 
+        ValType::Union{Symbol, Expr, Nothing} = nothing
+    end
+    if isnothing(ValType)
+        ValType = :Val
+        length(args) == 2 || error("Must provide exactly two arguments if `ValType` is not provided")
+        method_call, get_constant_method_name = args
+    else
+        length(args) == 3 || error("Must provide exactly three arguments when `ValType` is provided")
+        method_call, get_constant_method_name = args[2], args[3]
+    end
+    return method_def_constants_expr(method_call, get_constant_method_name, ValType) |> esc
+end

--- a/src/macro_util.jl
+++ b/src/macro_util.jl
@@ -4,91 +4,95 @@ inner_param(::Type{MIME{S}}) where {S} = S
 get_constant_func((@nospecialize x)) = nothing
 constant_key_type((@nospecialize x)) = Any 
 
-function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; transform_expr=nothing, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
-    f = from_expr(FuncCall, ref_method)
-    nargs = length(f.args)
-    val_arg_index::Union{Nothing,Int} = nothing 
-    local val_arg_expr::CurlyExpr{ValType, Any}
-    for i in 1:nargs 
-        g = _from_expr(CurlyExpr{ValType, Any}, f.args[i].type)
-        if !(g isa Exception)
-            val_arg_expr = g
-            val_arg_index = i 
-            break
-        end
-    end
-    (isnothing(val_arg_index) || length(val_arg_expr.args) != 1) && throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
-    if Meta.isexpr(val_arg_expr.args[1], :(::), 1)
-        ConstantType = only(val_arg_expr.args[1].args)
-    else
-        throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
-    end
-
-    ref_method_name = f.funcname
+@static if VERSION < v"1.10" 
     
-    _constant_method = gensym(get_constant_method)
-    get_constant_where_params = [Symbol("T$i") for i in 1:nargs]
-    get_constant_args = [FuncArg(; type=:(Type{$(get_constant_where_params[i])})) for i in 1:nargs if i != val_arg_index]
-    get_constant_body = FuncCall(; funcname=_constant_method, 
-        args=[FuncArg(; value=:(Tuple{$([ i == val_arg_index ? ValType : :(Type{$(get_constant_where_params[i])}) for i in 1:nargs]...)}))]
-    )
-    get_constant_method_def = FuncDef(; head=:(=), 
-        header=FuncCall(; funcname=get_constant_method, args=get_constant_args), 
-        whereparams= nargs > 1 ? [get_constant_where_params[i] for i in 1:nargs if i != val_arg_index] : not_provided,
-        body=Expr(:block, _sourceinfo, to_expr(get_constant_body)), 
-        line=something(_sourceinfo, not_provided), 
-        return_type=:(Vector{$ConstantType}))
-
-    get_constant_method_def = __doc__macro(get_constant_method_def)
-
-    output_expr = :($ConstantType[$inner_param(Base.fieldtype(m.sig,$(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(concrete_type_matches_only ? :(all(Base.fieldtype(m.sig, i) != Any for i in 1:nargs if i != $val_arg_index)) : true)])
-    if !isnothing(transform_expr)
-        output_expr = transform_expr(output_expr)
-    end
-    if ConstantType === :Symbol
-        returnvals = :(QuoteNode.(output))
-    else
-        returnvals = :(output)
-    end
-
-    return quote 
-        if isnothing($get_constant_func($ref_method_name))
-            @inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
-                $_sourceinfo
-                output = $output_expr
-                ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:vect, ($returnvals)...))
-                ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
-                return ci
+    function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; transform_expr=nothing, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
+        f = from_expr(FuncCall, ref_method)
+        nargs = length(f.args)
+        val_arg_index::Union{Nothing,Int} = nothing 
+        local val_arg_expr::CurlyExpr{ValType, Any}
+        for i in 1:nargs 
+            g = _from_expr(CurlyExpr{ValType, Any}, f.args[i].type)
+            if !(g isa Exception)
+                val_arg_expr = g
+                val_arg_index = i 
+                break
             end
+        end
+        (isnothing(val_arg_index) || length(val_arg_expr.args) != 1) && throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+        if Meta.isexpr(val_arg_expr.args[1], :(::), 1)
+            ConstantType = only(val_arg_expr.args[1].args)
+        else
+            throw(@arg_error ref_method "Must be a function call signature of the form `f(args..., ::$ValType{::Type}, args...)`")
+        end
 
-            $(to_expr(get_constant_method_def))
-            $MacroUtilities.get_constant_func(::typeof($ref_method_name)) = $_constant_method
-            $MacroUtilities.constant_key_type(::typeof($ref_method_name)) = $ConstantType
+        ref_method_name = f.funcname
+        
+        _constant_method = gensym(get_constant_method)
+        get_constant_where_params = [Symbol("T$i") for i in 1:nargs]
+        get_constant_args = [FuncArg(; type=:(Type{$(get_constant_where_params[i])})) for i in 1:nargs if i != val_arg_index]
+        get_constant_body = FuncCall(; funcname=_constant_method, 
+            args=[FuncArg(; value=:(Tuple{$([ i == val_arg_index ? ValType : :(Type{$(get_constant_where_params[i])}) for i in 1:nargs]...)}))]
+        )
+        get_constant_method_def = FuncDef(; head=:(=), 
+            header=FuncCall(; funcname=get_constant_method, args=get_constant_args), 
+            whereparams= nargs > 1 ? [get_constant_where_params[i] for i in 1:nargs if i != val_arg_index] : not_provided,
+            body=Expr(:block, _sourceinfo, to_expr(get_constant_body)), 
+            line=something(_sourceinfo, not_provided), 
+            return_type=:(Vector{$ConstantType}))
+
+        get_constant_method_def = __doc__macro(get_constant_method_def)
+
+        output_expr = :($ConstantType[$inner_param(Base.fieldtype(m.sig,$(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(concrete_type_matches_only ? :(all(Base.fieldtype(m.sig, i) != Any for i in 1:nargs if i != $val_arg_index)) : true)])
+        if !isnothing(transform_expr)
+            output_expr = transform_expr(output_expr)
+        end
+        if ConstantType === :Symbol
+            returnvals = :(QuoteNode.(output))
+        else
+            returnvals = :(output)
+        end
+
+        return quote 
+            if isnothing($get_constant_func($ref_method_name))
+                @inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
+                    $_sourceinfo
+                    output = $output_expr
+                    ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:vect, ($returnvals)...))
+                    ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
+                    return ci
+                end
+
+                $(to_expr(get_constant_method_def))
+                $MacroUtilities.get_constant_func(::typeof($ref_method_name)) = $_constant_method
+                $MacroUtilities.constant_key_type(::typeof($ref_method_name)) = $ConstantType
+            end
         end
     end
-end
 
-"""
-    @method_def_constant [ValType=Val] method_call get_constant_method
+    """
+        @method_def_constant [ValType=Val] method_call get_constant_method
 
-Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns a `Vector{S}` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
+    Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns a `Vector{S}` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
 
-`get_constant_method` is a generated function and thus incurs no runtime overhead, but also contains backedges to each method instance of `f`, and so the output is recompiled when a new method definition of `f` is added. 
+    `get_constant_method` is a generated function and thus incurs no runtime overhead, but also contains backedges to each method instance of `f`, and so the output is recompiled when a new method definition of `f` is added. 
 
-`ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
-"""
-macro method_def_constant(args...)
-    length(args) ≥ 1 || error("Must provide at least one argument")
-    @parse_kwargs args[1] begin 
-        ValType::Union{Symbol, Expr, Nothing} = nothing
+    `ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
+    """
+    macro method_def_constant(args...)
+        length(args) ≥ 1 || error("Must provide at least one argument")
+        @parse_kwargs args[1] begin 
+            ValType::Union{Symbol, Expr, Nothing} = nothing
+        end
+        if isnothing(ValType)
+            ValType = :Val
+            length(args) == 2 || error("Must provide exactly two arguments if `ValType` is not provided")
+            method_call, get_constant_method_name = args
+        else
+            length(args) == 3 || error("Must provide exactly three arguments when `ValType` is provided")
+            method_call, get_constant_method_name = args[2], args[3]
+        end
+        return method_def_constants_expr(method_call, get_constant_method_name, ValType) |> esc
     end
-    if isnothing(ValType)
-        ValType = :Val
-        length(args) == 2 || error("Must provide exactly two arguments if `ValType` is not provided")
-        method_call, get_constant_method_name = args
-    else
-        length(args) == 3 || error("Must provide exactly three arguments when `ValType` is provided")
-        method_call, get_constant_method_name = args[2], args[3]
-    end
-    return method_def_constants_expr(method_call, get_constant_method_name, ValType) |> esc
+
 end

--- a/src/parse_kwargs/kv_expr_parser.jl
+++ b/src/parse_kwargs/kv_expr_parser.jl
@@ -8,7 +8,6 @@ Base.:(==)(x::KVSpecExpr, y::KVSpecExpr) =  all(getfield(x,k) == getfield(y,k) f
 
 function parse_kv_spec_from_type_expr(expr)
     f = _from_expr(TypedVar, expr)
-    f isa Exception && return f 
     key = f.name 
     expected_types = Set()
     @switch f.type begin 

--- a/src/parsing/parsing.jl
+++ b/src/parsing/parsing.jl
@@ -28,6 +28,9 @@ function _from_expr(::Type{Symbol}, expr)
 end
 
 _from_expr(::Type{Expr}, expr::Expr) = expr 
+for T in (:Symbol, :Expr)
+    @eval _from_expr(::Type{Union{Symbol, Expr}}, expr::$T) = expr
+end
 
 _from_expr(::Type{Any}, expr) = expr 
 

--- a/test/macros/_test_macros.jl
+++ b/test/macros/_test_macros.jl
@@ -1,1 +1,3 @@
 include("test_parsing_macros.jl")
+include("test_parse_kwargs.jl")
+include("test_method_def_constant.jl")

--- a/test/macros/test_method_def_constant.jl
+++ b/test/macros/test_method_def_constant.jl
@@ -1,0 +1,28 @@
+function func1_for_constant end 
+
+@Test !(Base.@isdefined constant_from_func1)
+
+@method_def_constant func1_for_constant(::Val{::Symbol}) constant_from_func1
+
+@Test Base.@isdefined constant_from_func1
+
+function func2_for_constant end 
+
+@method_def_constant func2_for_constant(::Type{String}, ::Val{::Symbol}, ::Type{<:Real}) constant_from_func2
+
+@testset "@method_def_constant" begin 
+    @Test hasmethod(constant_from_func1, Tuple{})
+    @Test constant_from_func1() == Symbol[]
+    @inferred constant_from_func1()
+    @eval func1_for_constant(::Val{:key1}) = nothing
+    @Test constant_from_func1() == [:key1]
+    @eval func1_for_constant(::Val{:key2}) = nothing
+    @Test constant_from_func1() == [:key1, :key2]    
+
+    @Test constant_from_func2(String, Float64) == Symbol[]
+    @inferred constant_from_func2(String, Float64)
+    @eval func2_for_constant(::Type{String}, ::Val{:key1}, ::Type{Float64}) = nothing
+    @eval func2_for_constant(::Type{String}, ::Val{:key2}, ::Type{Float64}) = nothing
+    @Test constant_from_func2(String, Float64) == [:key1, :key2]    
+    @Test isempty(constant_from_func2(String, Int))
+end

--- a/test/macros/test_method_def_constant.jl
+++ b/test/macros/test_method_def_constant.jl
@@ -1,28 +1,31 @@
-function func1_for_constant end 
+@static if VERSION < v"1.10"
+    
+    function func1_for_constant end 
 
-@Test !(Base.@isdefined constant_from_func1)
+    @Test !(Base.@isdefined constant_from_func1)
 
-@method_def_constant func1_for_constant(::Val{::Symbol}) constant_from_func1
+    @method_def_constant func1_for_constant(::Val{::Symbol}) constant_from_func1
 
-@Test Base.@isdefined constant_from_func1
+    @Test Base.@isdefined constant_from_func1
 
-function func2_for_constant end 
+    function func2_for_constant end 
 
-@method_def_constant func2_for_constant(::Type{String}, ::Val{::Symbol}, ::Type{<:Real}) constant_from_func2
+    @method_def_constant func2_for_constant(::Type{String}, ::Val{::Symbol}, ::Type{<:Real}) constant_from_func2
 
-@testset "@method_def_constant" begin 
-    @Test hasmethod(constant_from_func1, Tuple{})
-    @Test constant_from_func1() == Symbol[]
-    @inferred constant_from_func1()
-    @eval func1_for_constant(::Val{:key1}) = nothing
-    @Test constant_from_func1() == [:key1]
-    @eval func1_for_constant(::Val{:key2}) = nothing
-    @Test constant_from_func1() == [:key1, :key2]    
+    @testset "@method_def_constant" begin 
+        @Test hasmethod(constant_from_func1, Tuple{})
+        @Test constant_from_func1() == Symbol[]
+        @inferred constant_from_func1()
+        @eval func1_for_constant(::Val{:key1}) = nothing
+        @Test constant_from_func1() == [:key1]
+        @eval func1_for_constant(::Val{:key2}) = nothing
+        @Test constant_from_func1() == [:key1, :key2]    
 
-    @Test constant_from_func2(String, Float64) == Symbol[]
-    @inferred constant_from_func2(String, Float64)
-    @eval func2_for_constant(::Type{String}, ::Val{:key1}, ::Type{Float64}) = nothing
-    @eval func2_for_constant(::Type{String}, ::Val{:key2}, ::Type{Float64}) = nothing
-    @Test constant_from_func2(String, Float64) == [:key1, :key2]    
-    @Test isempty(constant_from_func2(String, Int))
+        @Test constant_from_func2(String, Float64) == Symbol[]
+        @inferred constant_from_func2(String, Float64)
+        @eval func2_for_constant(::Type{String}, ::Val{:key1}, ::Type{Float64}) = nothing
+        @eval func2_for_constant(::Type{String}, ::Val{:key2}, ::Type{Float64}) = nothing
+        @Test constant_from_func2(String, Float64) == [:key1, :key2]    
+        @Test isempty(constant_from_func2(String, Int))
+    end
 end

--- a/test/macros/test_parse_kwargs.jl
+++ b/test/macros/test_parse_kwargs.jl
@@ -21,25 +21,16 @@ end
 
 @testset "@parse_kwargs" begin 
     @testset "KVSpecExpr" begin 
-        ex = :(key::String)
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String]))
-        ex = :(key::Union{String,Int})
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int]))
-        ex = :(key::Union{String,Int, Base.Float64})
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int, :(Base.Float64)]))
-        ex = :(key::Union{String,Int, Base.Float64} = "abcd")
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int, :(Base.Float64)]), default_value="abcd")
-        ex = :(key = (expected_type=String,))
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String]))
-        ex = :(key = (expected_types=(String,Int), default=1))
-        f = from_expr(MacroUtilities.KVSpecExpr, ex)
-        @Test f == MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int]), default_value=1)
-        
+        @test_cases begin 
+            input                                   | output
+            :(key::String)                          | MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String]))
+            :(key::Union{String,Int})               | MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int]))
+            :(key::Union{String,Int, Base.Float64}) |  MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int, :(Base.Float64)]))
+            :(key::Union{String,Int, Base.Float64} = "abcd") | MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int, :(Base.Float64)]), default_value="abcd")
+            :(key = (expected_type=String,))        | MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String]))
+            :(key = (expected_types=(String,Int), default=1))  | MacroUtilities.KVSpecExpr(; key=:key, expected_types=Set([:String, :Int]), default_value=1)
+            @test from_expr(MacroUtilities.KVSpecExpr, input) == output
+        end
     end
     @testset "KVExprParser" begin 
         parser = MacroUtilities.KVExprParser(MacroUtilities.KVSpec(; key=:key1, expected_types=Set([Bool, Int])), MacroUtilities.KVSpec(; key=:key2, expected_types=Set([Vector{Symbol}, Vector{String}]), default_value=[:default]))
@@ -58,8 +49,8 @@ end
         @testthrows "In `key1 = rhs` expression, rhs (= abc) has type String, which is not one of the expected types (Int64, Bool)" parse_kvs!(parser, [:(key1 = "abc")])
 
         empty!(parser.found_values)
-        @testthrows "Unexpected key `key3`, expected keys = (key1, key2)" parse_kvs!(parser, [:(key3 = "abc")])
-        
+        @testthrows "Unexpected key `key3`, expected keys = (key1, key2)" parse_kvs!(parser, [:(key3 = "abc")], strict=true)
+        @testthrows "ArgumentError: No value provided for key `key1" parse_kvs!(parser, [:(key3 = "abc")])
     end
    
     let 


### PR DESCRIPTION
fix(`@parse_kwargs`): Don't error on unexpected keys nor non `key=value` expressions