### PR TITLE
fix: Early exit from `from_expr` if result is an Exception

### DIFF
--- a/src/parsing/expr_types/base.jl
+++ b/src/parsing/expr_types/base.jl
@@ -45,7 +45,24 @@ function _from_expr(::Type{CurlyExpr{FirstArg, E}}, expr) where {FirstArg, E}
     end
 end
 
+function _from_expr(::Type{CurlyExpr}, expr)
+    @switch expr begin 
+        @case Expr(:curly, first_arg, args...)
+            output = convert(Vector{Any}, collect(args))
+            if first_arg isa Symbol 
+                FirstArg = first_arg 
+            else
+                FirstArg = Expr
+                pushfirst!(output, first_arg)
+            end
+            return CurlyExpr{FirstArg, Any}(output)
+        @case _ 
+            return ArgumentError("Input expression `$expr` is not a valid CurlyExpr expression")
+    end
+end
+
 to_expr(f::CurlyExpr{FirstArg, E}) where {FirstArg, E} = Expr(:curly, FirstArg, f.args...)
+to_expr(f::CurlyExpr{Expr, E}) where {E} = Expr(:curly, f.args...)
 
 """
     UnionExpr(; args::Vector{Union{Symbol, Expr}})

--- a/src/parsing/parsing.jl
+++ b/src/parsing/parsing.jl
@@ -69,10 +69,10 @@ If `normalize_kwargs = true`, trailing equality expressions (e.g., `f(a, b, c=1)
 """
 function from_expr(::Type{T}, expr; throw_error::Bool=false, kwargs...) where {T}
     result = _from_expr(T, expr; kwargs...)
-    if (T <: Vector && result isa Vector && eltype(result) <: eltype(T)) || result isa T || (T isa UnionAll ) || (!isempty(T.parameters) && result isa T.name.wrapper)
-        return result 
-    elseif result isa Exception
+    if result isa Exception 
         throw_error && throw(result)
+    elseif (T <: Vector && result isa Vector && eltype(result) <: eltype(T)) || result isa T || (T isa UnionAll ) || (!isempty(T.parameters) && result isa T.name.wrapper)
+        return result 
     end
     return nothing
 end

--- a/test/expressions/test_exprs.jl
+++ b/test/expressions/test_exprs.jl
@@ -56,6 +56,18 @@
         end
         @Test from_expr(UnionExpr, :(f(x))) |> isnothing
     end
+    @testset "CurlyExpr" begin 
+        @test_cases begin 
+            input               |   output 
+            :(Union{A,B})       | MacroUtilities.CurlyExpr{:Union, Any}(Any[:A, :B])
+            :(Union{})          | MacroUtilities.CurlyExpr{:Union, Any}(Any[])
+            :(Union{A, F(B)})   | MacroUtilities.CurlyExpr{:Union, Any}(Any[:A, :(F(B))])
+            :(F{A, G(B)})       | MacroUtilities.CurlyExpr{:F, Any}(Any[:A, :(G(B))])
+            :(H.F{A, G(B)})     | MacroUtilities.CurlyExpr{Expr, Any}(Any[:(H.F), :A, :(G(B))])
+            @test from_expr(MacroUtilities.CurlyExpr, input) == output
+            @test to_expr(output) == input
+        end
+    end
 
     @testset "NamedTupleExpr" begin 
         ex = :((a=1, b=f(x)))


### PR DESCRIPTION
fix: Fixed parsing for generic `CurlyExpr`