### PR TITLE
feat: Added `TypeVarExpr`, now exporting `CurlyExpr`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,6 +33,8 @@ NamedTupleArg
 NamedTupleArg(f::NamedTupleArg)
 NamedTupleExpr
 NamedTupleExpr(names::Vector{Symbol})
+TypeVarExpr
+CurlyExpr
 UnionExpr
 TypedVar
 TypedVar(d::TypedVar)

--- a/src/MacroUtilities.jl
+++ b/src/MacroUtilities.jl
@@ -11,7 +11,7 @@ module MacroUtilities
     export is_not_provided, is_provided, not_provided, NotProvided, MaybeProvided
 
     # Expression parsing types 
-    export UnionExpr, TypedVar, TypedExpr, AssignExpr, NamedTupleArg, NamedTupleExpr
+    export TypeVarExpr, CurlyExpr, UnionExpr, TypedVar, TypedExpr, AssignExpr, NamedTupleArg, NamedTupleExpr
     
     export BlockExpr, PairExpr, ExprWOptionalRhs, KVExpr, ExprWOptions, KeyWOptions, DestructuredAssigmentExpr
 

--- a/src/generation/constructors.jl
+++ b/src/generation/constructors.jl
@@ -16,7 +16,7 @@ function kwarg_constructor(typename, fields::Vector{TypedVar}, default_vals; lnn
     if !isnothing(lnn)
         pushfirst!(body.args, lnn)
     end
-    return FuncDef(; header=header, head=:(=), body=body, whereparams=whereparams)
+    return FuncDef(; header, head=:(=), body, whereparams)
 end
 
 """

--- a/src/parsing/parsing.jl
+++ b/src/parsing/parsing.jl
@@ -77,6 +77,7 @@ function from_expr(::Type{T}, expr; throw_error::Bool=false, kwargs...) where {T
     return nothing
 end
 
+from_expr(::Type{T}, expr::S; kwargs...) where {T, S<:T} = expr
 
 """
     to_expr(x) -> Expr 


### PR DESCRIPTION
refactor: `parameters` field in `StructDefHeader` is now a `TypeVarExpr`