### PR TITLE
feat(`@method_def_constant`): Added `map_expr` kwarg

### DIFF
--- a/src/macro_util.jl
+++ b/src/macro_util.jl
@@ -5,7 +5,18 @@ inner_param(@nospecialize x) = x
 get_constant_func((@nospecialize x)) = nothing
 constant_key_type((@nospecialize x)) = Any 
 
-function method_def_constants_expr( ref_method, get_constant_method, ValType::Union{Symbol, Expr}=:Val; concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing, ValueType=:Any)
+"""
+    default_extract_const_expr(constants) -> Expr 
+
+Returns a `Expr` which generates a tuple from the given constants
+"""
+default_extract_const_expr(constants) = Expr(:tuple, map( eltype(constants) === Symbol ? QuoteNode : identity, constants)...)
+
+function method_def_constants_expr( ref_method, get_constant_method; map_expr=nothing, ValType::Union{Symbol, Expr}=:Val, concrete_type_matches_only::Bool=false, _sourceinfo::Union{Nothing, LineNumberNode}=nothing)
+    @nospecialize
+    if isnothing(map_expr)
+        map_expr = :($default_extract_const_expr)
+    end
     f = from_expr(FuncCall, ref_method)
     nargs = length(f.args)
     val_arg_index::Union{Nothing,Int} = nothing 
@@ -49,7 +60,7 @@ function method_def_constants_expr( ref_method, get_constant_method, ValType::Un
             function $__constant_method(world, source, T, self, _T)
                 @nospecialize
                 output = $ConstantType[$inner_param($Base.fieldtype(m.sig, $(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T, nothing, world) if $(methods_if_expr)]
-                ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:tuple, map($(ConstantType === :Symbol ? :QuoteNode : :($Base.identity)), output)...))
+                ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), $(map_expr)(output))
                 ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T, world)
                 return ci
             end
@@ -63,7 +74,7 @@ function method_def_constants_expr( ref_method, get_constant_method, ValType::Un
         constant_method_def = :(@inline @generated function $_constant_method(_T::Type{T}) where {T<:Tuple}
             $_sourceinfo
             output = $ConstantType[$inner_param($Base.fieldtype(m.sig, $(val_arg_index+1))) for m in $Tricks._methods(typeof($ref_method_name), T) if $(methods_if_expr)]
-            ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), Expr(:tuple, map($(ConstantType === :Symbol ? :QuoteNode : :($Base.identity)), output)...))
+            ci = $Tricks.create_codeinfo_with_returnvalue([Symbol("#self#"), :_T], [:T], (:T,), $(map_expr)(output))
             ci.edges = $Tricks._method_table_all_edges_all_methods(typeof($ref_method_name), T)
             return ci
         end)
@@ -81,7 +92,7 @@ function method_def_constants_expr( ref_method, get_constant_method, ValType::Un
 end
 
 """
-    @method_def_constant [ValType=Val] method_call get_constant_method
+    @method_def_constant [ValType=Val] [map_expr] method_call get_constant_method
 
 Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::Type{Ti}, ::ValType{::S}, ::Type{Ti+1}, ..., ::Type{Tn})`, generates a method definition for `get_constant_method` which returns an iterable with element type `S` of all of the compile-time constants contained in the `ValType` parameter of each definition of `f`. 
 
@@ -89,19 +100,18 @@ Given a `method_call` expression of the form `f(::Type{T1}, ::Type{T2}, ..., ::T
 
 `ValType` must be a singleton type with a single parameter. Define `MacroUtilities.inner_param` to extract the innermost type parameter for your own custom types. 
 
+If `map_expr` is provided, it must resolve to a function mapping the collection of constants of type `Vector{S}` to a `Expr`. Defaults to `MacroUtilities.default_extract_const_expr`.
+
 """
 macro method_def_constant(args...)
-    length(args) ≥ 1 || error("Must provide at least one argument")
-    @parse_kwargs args[1] begin 
+    length(args) ≥ 2 || error("Must provide at least two arguments")
+    @parse_kwargs args[1:end-2]... begin 
         ValType::Union{Symbol, Expr, Nothing} = nothing
+        map_expr::Union{Symbol, Expr, Nothing} = nothing
     end
+    method_call, get_constant_method_name = args[end-1], args[end]
     if isnothing(ValType)
         ValType = :Val
-        length(args) == 2 || error("Must provide exactly two arguments if `ValType` is not provided")
-        method_call, get_constant_method_name = args
-    else
-        length(args) == 3 || error("Must provide exactly three arguments when `ValType` is provided")
-        method_call, get_constant_method_name = args[2], args[3]
     end
-    return method_def_constants_expr(method_call, get_constant_method_name, ValType; _sourceinfo=__source__) |> esc
+    return method_def_constants_expr(method_call, get_constant_method_name; ValType, map_expr, _sourceinfo=__source__) |> esc
 end

--- a/src/parsing/funcs.jl
+++ b/src/parsing/funcs.jl
@@ -219,6 +219,10 @@ function _from_expr(::Type{FuncCall}, expr; normalize_kwargs::Bool=false)
                 _args, _kwargs = _parse_args_kwargs(in_args)
             end
             (not_provided, _args, _kwargs)
+        @case Expr(:..., in_args)
+            (not_provided, Any[expr], nothing)
+        @case ::Symbol
+            (not_provided, Any[expr], nothing)
         @case _ 
             return ArgumentError("Input expression `$expr` is not a function call expression")
     end

--- a/test/TestMacroUtilities.jl
+++ b/test/TestMacroUtilities.jl
@@ -2,10 +2,10 @@ module TestMacroUtilities
     using MacroUtilities, MacroUtilities.MLStyle
     using TestingUtilities, Test 
 
-    if VERSION ≥ v"1.7"
+    if VERSION ≥ v"1.9"
         macro testthrows(msg, ex)
             return quote 
-                Test.@test_throws $msg $ex
+                $Test.@test_throws $msg $ex
             end |> esc 
         end
     else

--- a/test/macros/test_method_def_constant.jl
+++ b/test/macros/test_method_def_constant.jl
@@ -10,6 +10,11 @@ function func2_for_constant end
 
 @method_def_constant func2_for_constant(::Type{String}, ::Val{::Symbol}, ::Type{<:Real}) constant_from_func2
 
+function func3_for_constant end
+constant_expr_map(output) = to_expr(NamedTupleExpr([NamedTupleArg(; key, value=:($func3_for_constant(Val{$(QuoteNode(key))}())), kw_head=false) for key in output]))
+@method_def_constant map_expr=constant_expr_map func3_for_constant(::Val{::Symbol}) constants_from_func3
+
+
 @testset "@method_def_constant" begin 
     @Test hasmethod(constant_from_func1, Tuple{})
     @Test constant_from_func1() == ()
@@ -29,4 +34,15 @@ function func2_for_constant end
     @Test consts isa Tuple && eltype(consts) == Symbol && length(consts) == 2
     @Test Set(consts) == Set((:key2, :key1))
     @Test isempty(constant_from_func2(String, Int))
+
+    consts = @inferred constants_from_func3()  
+    @Test isempty(consts)
+    @eval func3_for_constant(::Val{:key1}) = String 
+    consts = @inferred constants_from_func3()  
+    @Test consts == (key1=String,)
+    @eval func3_for_constant(::Val{:key3}) = Int 
+    consts = @inferred constants_from_func3()  
+    @Test Set(keys(consts)) == Set([:key1, :key3])
+    @Test Set(values(consts)) == Set([String, Int])
+    
 end

--- a/test/macros/test_parsing_macros.jl
+++ b/test/macros/test_parsing_macros.jl
@@ -187,12 +187,12 @@ end
             @test arg1 == 2
         end
 
-        if VERSION ≥ v"1.7"
-            @test_throws "Expected type of `arg1` to be Int, got typeof(arg1) = Float64" @eval module A 
-                import ..@ex_macro3 
-                @ex_macro3 1.0
-            end
+    
+        @testthrows "Expected type of `arg1` to be Int, got typeof(arg1) = Float64" @eval module A 
+            import ..@ex_macro3 
+            @ex_macro3 1.0
         end
+    
 
     end
 end


### PR DESCRIPTION
fix: Allow `FuncDef` parsing of single-arg anonymous function expressions